### PR TITLE
Adjust tree height growth to be 10x the input value

### DIFF
--- a/script.js
+++ b/script.js
@@ -484,9 +484,13 @@ document.addEventListener('DOMContentLoaded', () => {
     // Event Listeners for UI
     growHeightButton.addEventListener('click', () => {
         if (trees.length > 0) {
-            const amount = parseInt(growHeightInput.value, 10) || 1;
-            trees[0].growHeight(amount); // Pass the amount
-            trees[0].growWidth(amount * 0.05); // Scale width growth with height growth
+            const inputAmount = parseInt(growHeightInput.value, 10) || 1;
+            const growthAmount = inputAmount * 10; // Scale factor of 10
+            trees[0].growHeight(growthAmount);
+            // Width growth should be relative to the input unit, not the final pixel growth,
+            // to maintain the same proportional feel as before.
+            // E.g., input 1 (grows 10px) should have same width increase as input 1 before this change.
+            trees[0].growWidth(inputAmount * 0.05);
             updateScore();
         }
     });


### PR DESCRIPTION
The 'Höher wachsen' input now acts as a multiplier for a base growth of 10 pixels. For example, an input of '1' results in 10px height growth, '2' results in 20px, and so on.

The proportional width growth remains scaled to the original input unit to maintain the established visual characteristic (i.e., input '1' results in the same width increase as it did before this height scaling change).