### PR TITLE
Fix: Enable 'Grow Leaves' button immediately after adding a branch

### DIFF
--- a/script.js
+++ b/script.js
@@ -628,7 +628,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 }
             }
         }
-        // updateScore(); // Branches might contribute to score later, if desired
+        updateScore(); // Branches might contribute to score later, if desired
     });
 
     // Helper function in Tree class to get all branches (main + children)


### PR DESCRIPTION
The 'Grow Leaves' button was not updating its state immediately after a branch was added. This was because `updateScore()`, which subsequently calls `updateButtonStates()`, was not being called in the `addBranchButton` event listener.

This commit adds a call to `updateScore()` after a branch is created, ensuring the UI, including the 'Grow Leaves' button state, is refreshed promptly.