### PR TITLE
Fix: Set tree initial Y position to 830px from top

### DIFF
--- a/script.js
+++ b/script.js
@@ -535,7 +535,7 @@ document.addEventListener('DOMContentLoaded', () => {
         // Create the first tree
         if (trees.length === 0) {
             const initialTreeX = canvas.width / 2;
-            const initialTreeY = canvas.height - GROUND_LEVEL_OFFSET;
+            const initialTreeY = 830; // Fixed position from the top
             trees.push(new Tree(initialTreeX, initialTreeY));
         }
         updateButtonStates(); // Centralized button state management


### PR DESCRIPTION
Modified script.js to change the initial Y coordinate of the tree to a fixed value of 830px from the top of the canvas, as per the requirement.

The GROUND_LEVEL_OFFSET constant, previously used for this calculation, is still used for other elements like background positioning and new tree placement. These may need further adjustments if they are intended to align with the new fixed tree position.