### PR TITLE
Fix: Limit input fields to 4 digits using JavaScript

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,27 +16,27 @@
                 <div id="tree-controls">
                 <div>
                     <label for="grow-height-input" class="visually-hidden">Anzahl Höhe</label>
-                    <input type="number" id="grow-height-input" value="1" min="1" max="9999" aria-label="Anzahl für Höhe wachstum">
+                    <input type="number" id="grow-height-input" value="1" min="1" aria-label="Anzahl für Höhe wachstum">
                     <button id="grow-height-button">Höher wachsen</button>
                 </div>
                 <div>
                     <label for="grow-roots-input" class="visually-hidden">Anzahl Wurzeln</label>
-                    <input type="number" id="grow-roots-input" value="1" min="1" max="9999" aria-label="Anzahl für Wurzeln bilden">
+                    <input type="number" id="grow-roots-input" value="1" min="1" aria-label="Anzahl für Wurzeln bilden">
                     <button id="grow-roots-button">Wurzeln bilden</button>
                 </div>
                 <div>
                     <label for="grow-leaves-input" class="visually-hidden">Anzahl Blätter</label>
-                    <input type="number" id="grow-leaves-input" value="1" min="1" max="9999" aria-label="Anzahl für Blätter bilden">
+                    <input type="number" id="grow-leaves-input" value="1" min="1" aria-label="Anzahl für Blätter bilden">
                     <button id="grow-leaves-button">Blätter bilden</button>
                 </div>
                 <div>
                     <label for="add-branch-input" class="visually-hidden">Anzahl Äste</label>
-                    <input type="number" id="add-branch-input" value="1" min="1" max="9999" aria-label="Anzahl für Ast bilden">
+                    <input type="number" id="add-branch-input" value="1" min="1" aria-label="Anzahl für Ast bilden">
                     <button id="add-branch-button">Ast bilden</button>
                 </div>
                 <div>
                     <label for="produce-fruit-input" class="visually-hidden">Anzahl Früchte</label>
-                    <input type="number" id="produce-fruit-input" value="1" min="1" max="9999" aria-label="Anzahl für Früchte produzieren">
+                    <input type="number" id="produce-fruit-input" value="1" min="1" aria-label="Anzahl für Früchte produzieren">
                     <button id="produce-fruit-button" disabled>Früchte produzieren</button>
                 </div>
             </div>

--- a/script.js
+++ b/script.js
@@ -656,6 +656,22 @@ document.addEventListener('DOMContentLoaded', () => {
     const addBranchInput = document.getElementById('add-branch-input');
     const produceFruitInput = document.getElementById('produce-fruit-input');
 
+    // Function to limit input length
+    function limitInputLength(inputElement, maxLength) {
+        inputElement.addEventListener('input', () => {
+            if (inputElement.value.length > maxLength) {
+                inputElement.value = inputElement.value.slice(0, maxLength);
+            }
+        });
+    }
+
+    // Apply the length limit to all relevant input fields
+    limitInputLength(growHeightInput, 4);
+    limitInputLength(growRootsInput, 4);
+    limitInputLength(growLeavesInput, 4);
+    limitInputLength(addBranchInput, 4);
+    limitInputLength(produceFruitInput, 4);
+
     // Game Setup
     function initializeGame() {
         resizeCanvas(); // Call resizeCanvas first to set correct canvas dimensions


### PR DESCRIPTION
- Reverted previous changes that used the 'max' HTML attribute.
- Added JavaScript event listeners to number input fields.
- These listeners truncate the input value to 4 characters if it exceeds the limit, providing a stricter enforcement.